### PR TITLE
Secure storage of Live Broadcasting credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   # Common
 
   # Build flags common to OS X and Linux.
-  - export COMMON="test=1 mad=1 faad=1 ffmpeg=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1"
+  - export COMMON="test=1 mad=1 faad=1 ffmpeg=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 qtkeychain=1"
 
   #####
   # Ubuntu Trusty Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg libjpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile; fi
+  # Install QtKeychain
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install https://raw.githubusercontent.com/owncloud/homebrew-owncloud/a37691690e66de90e83842251d3a953024bd1244/qtkeychain.rb ; fi
 
 install:
   ####

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
       - protobuf-compiler
       - scons
       - vamp-plugin-sdk
+      - qtkeychain-dev
 before_install:
   # Virtual X, needed for analyzer waveform tests
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0         ; fi

--- a/SConstruct
+++ b/SConstruct
@@ -63,8 +63,9 @@ available_features = [features.Mad,
                       features.IPod,
                       features.FFMPEG,
 
-		     # Experimental features
-		     features.OpenGLES
+                      # Experimental features
+                      features.OpenGLES,
+                      features.QtKeychain
                       ]
 
 build = mixxx.MixxxBuild(target, machine, build_type,

--- a/build/depends.py
+++ b/build/depends.py
@@ -632,6 +632,12 @@ class Reverb(Dependence):
     def sources(self, build):
         return ['#lib/reverb/Reverb.cc']
 
+class QtKeychain(Dependence):
+    def configure(self, build, conf):
+        libs = ['qtkeychain']
+        if not conf.CheckLib(libs):
+            raise Exception(
+                "Could not find qtkeychain.")
 
 class MixxxCore(Feature):
 
@@ -1417,7 +1423,7 @@ class MixxxCore(Feature):
         return [SoundTouch, ReplayGain, Ebur128Mit, PortAudio, PortMIDI, Qt, TestHeaders,
                 FidLib, SndFile, FLAC, OggVorbis, OpenGL, TagLib, ProtoBuf,
                 Chromaprint, RubberBand, SecurityFramework, CoreServices, IOKit,
-                QtScriptByteArray, Reverb, FpClassify, PortAudioRingBuffer]
+                QtScriptByteArray, Reverb, FpClassify, PortAudioRingBuffer, QtKeychain]
 
     def post_dependency_check_configure(self, build, conf):
         """Sets up additional things in the Environment that must happen

--- a/build/depends.py
+++ b/build/depends.py
@@ -1423,7 +1423,7 @@ class MixxxCore(Feature):
         return [SoundTouch, ReplayGain, Ebur128Mit, PortAudio, PortMIDI, Qt, TestHeaders,
                 FidLib, SndFile, FLAC, OggVorbis, OpenGL, TagLib, ProtoBuf,
                 Chromaprint, RubberBand, SecurityFramework, CoreServices, IOKit,
-                QtScriptByteArray, Reverb, FpClassify, PortAudioRingBuffer, QtKeychain]
+                QtScriptByteArray, Reverb, FpClassify, PortAudioRingBuffer]
 
     def post_dependency_check_configure(self, build, conf):
         """Sets up additional things in the Environment that must happen

--- a/build/features.py
+++ b/build/features.py
@@ -1300,3 +1300,28 @@ class Battery(Feature):
 
     def depends(self, build):
         return [depends.IOKit, depends.UPower]
+
+class QtKeychain(Feature):
+    def description(self):
+        return "Secure credentials storage support for Live Broadcasting profiles"
+
+    def enabled(self, build):
+        build.flags['qtkeychain'] = util.get_flags(build.env, 'qtkeychain', 0)
+        if int(build.flags['qtkeychain']):
+            return True
+        return False
+
+    def add_options(self, build, vars):
+        vars.Add('qtkeychain', 'Set to 1 to enable secure credentials storage support for Live Broadcasting profiles', 1)
+
+    def configure(self, build, conf):
+        if not self.enabled(build):
+            return
+
+        build.env.Append(CPPDEFINES='__QTKEYCHAIN__')
+
+    def sources(self, build):
+        return []
+
+    def depends(self, build):
+        return [depends.QtKeychain]

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -412,7 +412,7 @@ QString BroadcastProfile::getSecureValue(QString key) {
 
     QEventLoop loop;
     readJob.connect(&readJob, SIGNAL(finished(QKeychain::Job*)),
-                    &loop, SIGNAL(quit()));
+                    &loop, SLOT(quit()));
     readJob.start();
     loop.exec();
 

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -243,11 +243,10 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_port = XmlParse::selectNodeInt(doc, kPort);
     m_serverType = XmlParse::selectNodeQString(doc, kServertype);
 
+    m_login = XmlParse::selectNodeQString(doc, kLogin);
     if(m_secureCredentials) {
-        m_login = getSecureValue(kLogin);
-        m_password = getSecureValue(kPassword);
+        m_password = getSecurePassword(m_login);
     } else {
-        m_login = XmlParse::selectNodeQString(doc, kLogin);
         m_password = XmlParse::selectNodeQString(doc, kPassword);
     }
 
@@ -301,11 +300,10 @@ bool BroadcastProfile::save(const QString& filename) {
     XmlParse::addElement(doc, docRoot, kPort, QString::number(m_port));
     XmlParse::addElement(doc, docRoot, kServertype, m_serverType);
 
+    XmlParse::addElement(doc, docRoot, kLogin, m_login);
     if(m_secureCredentials) {
-        setSecureValue(kLogin, m_login);
-        setSecureValue(kPassword, m_password);
+        setSecurePassword(m_login, m_password);
     } else {
-        XmlParse::addElement(doc, docRoot, kLogin, m_login);
         XmlParse::addElement(doc, docRoot, kPassword, m_password);
     }
 
@@ -379,13 +377,13 @@ bool BroadcastProfile::secureCredentialStorage() {
     return m_secureCredentials;
 }
 
-bool BroadcastProfile::setSecureValue(QString key, QString value) {
+bool BroadcastProfile::setSecurePassword(QString login, QString password) {
     QString serviceName = QString(kKeychainPrefix) + getProfileName();
 
     WritePasswordJob writeJob(serviceName);
     writeJob.setAutoDelete(false);
-    writeJob.setKey(key);
-    writeJob.setTextData(value);
+    writeJob.setKey(login);
+    writeJob.setTextData(password);
 
     QEventLoop loop;
     writeJob.connect(&writeJob, SIGNAL(finished(QKeychain::Job*)),
@@ -403,12 +401,12 @@ bool BroadcastProfile::setSecureValue(QString key, QString value) {
     }
 }
 
-QString BroadcastProfile::getSecureValue(QString key) {
+QString BroadcastProfile::getSecurePassword(QString login) {
     QString serviceName = QString(kKeychainPrefix) + getProfileName();
 
     ReadPasswordJob readJob(serviceName);
     readJob.setAutoDelete(false);
-    readJob.setKey(key);
+    readJob.setKey(login);
 
     QEventLoop loop;
     readJob.connect(&readJob, SIGNAL(finished(QKeychain::Job*)),

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -394,7 +394,7 @@ bool BroadcastProfile::setSecureValue(QString key, QString value) {
     loop.exec();
 
     if(writeJob.error() == Error::NoError) {
-        qDebug() << "BroadcastProfile::setSecureValue: success";
+        qDebug() << "BroadcastProfile::setSecureValue: write successful";
         return true;
     } else {
         qDebug() << "BroadcastProfile::setSecureValue: write job failed with error:"
@@ -417,7 +417,7 @@ QString BroadcastProfile::getSecureValue(QString key) {
     loop.exec();
 
     if(readJob.error() == Error::NoError) {
-        qDebug() << "BroadcastProfile::getSecureValue: success";
+        qDebug() << "BroadcastProfile::getSecureValue: read successful";
         return readJob.textData();
     } else {
         qDebug() << "BroadcastProfile::getSecureValue: read job failed with error:"

--- a/src/preferences/broadcastprofile.h
+++ b/src/preferences/broadcastprofile.h
@@ -29,6 +29,9 @@ class BroadcastProfile : public QObject {
     static bool validName(const QString& str);
     static QString stripForbiddenChars(const QString& str);
 
+    void setSecureCredentialStorage(bool enabled);
+    bool secureCredentialStorage();
+
     void setProfileName(const QString& profileName);
     QString getProfileName() const;
 
@@ -120,8 +123,12 @@ class BroadcastProfile : public QObject {
     void adoptDefaultValues();
     bool loadValues(const QString& filename);
 
-    QString m_profileName;
+    bool setSecureValue(QString key, QString value);
+    QString getSecureValue(QString key);
 
+    bool m_secureCredentials;
+
+    QString m_profileName;
     bool m_enabled;
 
     QString m_host;

--- a/src/preferences/broadcastprofile.h
+++ b/src/preferences/broadcastprofile.h
@@ -123,8 +123,8 @@ class BroadcastProfile : public QObject {
     void adoptDefaultValues();
     bool loadValues(const QString& filename);
 
-    bool setSecureValue(QString key, QString value);
-    QString getSecureValue(QString key);
+    bool setSecurePassword(QString login, QString password);
+    QString getSecurePassword(QString login);
 
     bool m_secureCredentials;
 

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -26,6 +26,14 @@ DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
           m_pBroadcastSettings(pBroadcastSettings),
           m_pProfileListSelection(nullptr) {
     setupUi(this);
+
+#ifndef __QTKEYCHAIN__
+    // If secure storage is disabled, hide the checkbox
+    // and force the value to false.
+    cbSecureCredentials->setVisible(false);
+    cbSecureCredentials->setChecked(false);
+#endif
+
     connect(profileList->horizontalHeader(), SIGNAL(sectionResized(int, int, int)),
             this, SLOT(onSectionResized()));
     connect(cbRemoveMode, SIGNAL(stateChanged(int)),

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -117,6 +117,7 @@ void DlgPrefBroadcast::slotResetToDefaults() {
 
     // Make sure to keep these values in sync with the constructor.
     enableLiveBroadcasting->setChecked(false);
+    cbSecureCredentials->setChecked(false);
     comboBoxServerType->setCurrentIndex(0);
     mountpoint->setText(dProfile.getMountpoint());
     host->setText(dProfile.getHost());
@@ -260,6 +261,8 @@ void DlgPrefBroadcast::getValuesFromProfile(BroadcastProfilePtr profile) {
             .arg(profile->getProfileName());
     groupBoxProfileSettings->setTitle(headerText);
 
+    cbSecureCredentials->setChecked(profile->secureCredentialStorage());
+
     // Server type combo list
     int tmp_index = comboBoxServerType->findData(profile->getServertype());
     if (tmp_index < 0) { // Set default if invalid.
@@ -367,6 +370,8 @@ void DlgPrefBroadcast::getValuesFromProfile(BroadcastProfilePtr profile) {
 void DlgPrefBroadcast::setValuesToProfile(BroadcastProfilePtr profile) {
     if(!profile)
         return;
+
+    profile->setSecureCredentialStorage(cbSecureCredentials->isChecked());
 
     // Combo boxes, make sure to load their data not their display strings.
     profile->setServertype(comboBoxServerType->itemData(

--- a/src/preferences/dialog/dlgprefbroadcastdlg.ui
+++ b/src/preferences/dialog/dlgprefbroadcastdlg.ui
@@ -233,6 +233,19 @@
            </item>
           </layout>
          </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="cbSecureCredentials">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Store username and password in the System Keychain</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>


### PR DESCRIPTION
This PR adds secure credentials storage to Live Broadcasting XML profiles.
Secure credentials storage uses Frank Osterfeld's QtKeychain to store sensitive profile information into the OS' password keychain. Because it uses the OS' keychain, it is an optional feature enabled or disabled per profile.